### PR TITLE
Updated the Makefile and the iot-stream-server Dockerfile

### DIFF
--- a/Dockerfiles/iot/stream_server/Dockerfile
+++ b/Dockerfiles/iot/stream_server/Dockerfile
@@ -1,5 +1,6 @@
 # using directly aler9/rtsp-simple-server fails ing GN3 for some reason...
-FROM aler9/rtsp-simple-server AS rtsp
+
+FROM aler9/rtsp-simple-server:v0.18.3 AS rtsp
 
 FROM alpine
 COPY --from=rtsp /rtsp-simple-server /

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ templates: Dockerfiles/certificates/Dockerfile Dockerfiles/DNS/dnsmasq.conf \
            Dockerfiles/malware/Mirai/Dockerfile.cnc Dockerfiles/malware/Mirai/Dockerfile.builder
 
 vyosiso:
-	wget https://s3.amazonaws.com/s3-us.vyos.io/snapshot/vyos-1.3.0-rc6/vyos-1.3.0-rc6-amd64.iso
-	mv -v vyos-1.3.0-rc6-amd64.iso $(shell xdg-user-dir DOWNLOAD)
+	wget https://s3-us.vyos.io/rolling/current/vyos-1.4-rolling-202304020811-amd64.iso
+	mv -v vyos-1.4-rolling-202304020811-amd64.iso $(shell xdg-user-dir DOWNLOAD)
 	wget https://sourceforge.net/projects/gns-3/files/Empty%20Qemu%20disk/empty8G.qcow2
 	mv -v empty8G.qcow2 $(shell xdg-user-dir DOWNLOAD)
 


### PR DESCRIPTION
Updated the VyOS from 1.3.0 to 1.4.0 nightly since 1.3.0 is no linger available for non-contributors.

Tagged the stream_server Dockerfile as v0.18.3 to make it work.